### PR TITLE
fix: add typescript module

### DIFF
--- a/lua/lspinstall/servers/typescript.lua
+++ b/lua/lspinstall/servers/typescript.lua
@@ -5,6 +5,6 @@ config.default_config.cmd[1] = "./node_modules/.bin/typescript-language-server"
 return vim.tbl_extend('error', config, {
   install_script = [=[
   [[ ! -f package.json ]] && npm init -y --scope=lspinstall || true
-  npm install typescript-language-server@latest
+  npm install typescript-language-server@latest typescript@latest
   ]=]
 })


### PR DESCRIPTION
I was trying to use tsserver and I couldn't get it to work. I started looking at package.json and saw that typescript package was missing which is required for typescript-language-server to work. Now it should work.