### PR TITLE
Add JDTLS with Lombok

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ end
 | go          | gopls                                                                       |
 | graphql     | GraphQL language service                                                    |
 | html        | html-language-features (pulled directly from the latest VSCode release)     |
+| java        | Latest Eclipse JDTLS with Lombok support.                                   |
 | json        | json-language-features (pulled directly from the latest VSCode release)     |
 | latex       | texlab                                                                      |
 | lua         | (sumneko) lua-language-server                                               |

--- a/lua/lspinstall/servers.lua
+++ b/lua/lspinstall/servers.lua
@@ -10,6 +10,7 @@ local servers = {
   ["go"] = require'lspinstall/servers/go',
   ["graphql"] = require'lspinstall/servers/graphql',
   ["html"] = require'lspinstall/servers/html',
+  ["java"] = require'lspinstall/servers/java',
   ["json"] = require'lspinstall/servers/json',
   ["latex"] = require'lspinstall/servers/latex',
   ["lua"] = require'lspinstall/servers/lua',

--- a/lua/lspinstall/servers/java.lua
+++ b/lua/lspinstall/servers/java.lua
@@ -1,0 +1,68 @@
+local config = require'lspconfig'.jdtls.document_config
+require'lspconfig/configs'.jdtls = nil -- important, immediately unset the loaded config again
+
+config.default_config.cmd[1] = {"./jdtls.sh", vim.fn.expand('$HOME/.local/share/nvim/lspinstall/java/workspace/') .. vim.fn.fnamemodify(vim.fn.getcwd(), ':p:h:t')}
+
+return vim.tbl_extend('error', config, {
+  install_script = [[
+  curl -L -o - http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz | tar xvz
+  curl -L -o lombok.jar https://projectlombok.org/downloads/lombok.jar
+
+  mkdir -p gradle
+
+cat << EOF > gradle/build.gradle
+task getHomeDir {
+    println gradle.gradleHomeDir
+}
+EOF
+
+cat << EOF > jdtls.sh
+#!/usr/bin/env bash
+OS=$(uname)
+
+case \$OS in
+  Linux)
+    CONFIG="$HOME/.local/share/nvim/lspinstall/java/config_linux"
+    ;;
+  Darwin)
+    CONFIG="$HOME/.local/share/nvim/lspinstall/java/config_mac"
+    ;;
+esac
+
+WORKSPACE="$(pwd)/workspace"
+
+# Check if Gradle is installed and if it is set the GRADLE_HOME environment variable.
+if command -v gradle &>/dev/null; then
+  export GRADLE_HOME="\$(cd $HOME/.local/share/nvim/lspinstall/java/gradle && gradle getHomeDir | grep -A1 'Configure project' | tail -n1)"
+fi
+
+JAR="$(find $HOME/.local/share/nvim/lspinstall/java/plugins/ -name 'org.eclipse.equinox.launcher_*.jar')"
+
+if [ -z \${JAVA_HOME+x} ]; then 
+  JAVA="\$(java -XshowSettings:properties -version 2>&1 > /dev/null | awk '/java.home/ { print \$3 }')/bin/java"
+else
+  JAVA="\${JAVA_HOME}/bin/java"
+fi
+
+mkdir -p \$WORKSPACE
+
+"\${JAVA}" \\
+  -Declipse.application=org.eclipse.jdt.ls.core.id1 \\
+  -Dosgi.bundles.defaultStartLevel=4 \\
+  -Declipse.product=org.eclipse.jdt.ls.core.product \\
+  -Dlog.protocol=true \\
+  -Dlog.level=ALL \\
+  -Xms1g \\
+  -Xmx2G \\
+  -jar "\$JAR" \\
+  -configuration "\$CONFIG" \\
+  -data "\${1:-\$HOME/workspace}" \\
+  --add-modules=ALL-SYSTEM \\
+  --add-opens java.base/java.util=ALL-UNNAMED \\
+  --add-opens java.base/java.lang=ALL-UNNAMED \\
+  -javaageng:$(pwd)/lombok.jar \\
+  -Xbootclasspath/p:$(pwd)/lombok.jar
+EOF
+chmod +x jdtls.sh
+  ]]
+})


### PR DESCRIPTION
* Installs the Java JDTLS language server with Lombok support.
* Handles identifying and setting the GRADLE_HOME environment variable on startup of the LSP. Only sets and uses GRADLE_HOME if Gradle is installed at the time of LSP startup.
* Uses the JAVA_HOME environment variable if set and if not it uses java to find out what it's java home directory is. 