### PR TITLE
Use isdirectory() instead of shelling out

### DIFF
--- a/lua/lspinstall.lua
+++ b/lua/lspinstall.lua
@@ -80,7 +80,7 @@ end
 -- UTILITY
 
 function M.is_server_installed(lang)
-  return os.execute("test -d " .. install_path(lang)) == 0
+  return vim.fn.isdirectory(install_path(lang)) == 1
 end
 
 function M.available_servers()


### PR DESCRIPTION
This provides a roughly 1000% performance boost on my laptop;
reducing the runtime of `require("lspinstall").installed_servers` from
around 200-300ms to 0.2-0.3ms.

This is useful for me, since I want to configure the LSP servers at neovim
startup, but also I don't want to wait more than ~100ms for the editor to
start.

Here is some lua to demonstrate the difference in techniques:

```lua
-- copy this to a neovim buffer, save the file, and run :luafile %
lspinstall = require('lspinstall')

function profile(func)
  local start_time = vim.loop.hrtime() -- gets a nanosecond precision timestamp
  local return_value = func()
  local end_time = vim.loop.hrtime()

  return ((end_time - start_time) / 1e6) -- return as milliseconds
end

print(profile(lspinstall.installed_servers))

function my_installed_servers()
  return vim.tbl_filter(
    function(key)
      return vim.fn.isdirectory(vim.fn.stdpath("data") .. "/lspinstall/" .. key) == 1
    end,
    lspinstall.available_servers()
  )
end
print(profile(my_installed_servers))
```