### PR TITLE
Add initial elixir-ls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ end
 | cpp         | clangd                                                                      |
 | cmake       | cmake-language-server                                                       |
 | css         | css-language-features (pulled directly from the latest VSCode release)      |
+| elixir      | Elixir Language Server (elixir-ls)                                          |
 | dockerfile  | docker-langserver                                                           |
 | go          | gopls                                                                       |
 | graphql     | GraphQL language service                                                    |

--- a/lua/lspinstall/servers.lua
+++ b/lua/lspinstall/servers.lua
@@ -8,6 +8,7 @@ local servers = {
   ["diagnosticls"] = require'lspinstall/servers/diagnosticls',
   ["dockerfile"] = require'lspinstall/servers/dockerfile',
   ["efm"] = require'lspinstall/servers/efm',
+  ["elixir"] = require'lspinstall/servers/elixir',
   ["go"] = require'lspinstall/servers/go',
   ["graphql"] = require'lspinstall/servers/graphql',
   ["html"] = require'lspinstall/servers/html',

--- a/lua/lspinstall/servers/elixir.lua
+++ b/lua/lspinstall/servers/elixir.lua
@@ -1,11 +1,13 @@
 local config = require'lspconfig'.elixirls.document_config
 require'lspconfig/configs'.elixirls = nil -- important, immediately unset the loaded config again
+config.default_config.cmd = { "elixir-ls/language_server.sh" }
 
 return vim.tbl_extend('error', config, {
   install_script = [[
+    rm -rf elixir-ls
     curl -fLO https://github.com/elixir-lsp/elixir-ls/releases/latest/download/elixir-ls.zip
-    unzip elixir-ls.zip
-    chmod +x language_server.sh
+    unzip elixir-ls.zip -d elixir-ls
+    chmod +x elixir-ls/language_server.sh
     rm -f elixir-ls.zip
   ]],
 })

--- a/lua/lspinstall/servers/elixir.lua
+++ b/lua/lspinstall/servers/elixir.lua
@@ -3,13 +3,9 @@ require'lspconfig/configs'.elixirls = nil -- important, immediately unset the lo
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/elixir-lsp/elixir-ls/releases/latest | grep 'browser' | grep 'elixir-ls.zip' | cut -d '"' -f4)
-    curl -L -o elixir-ls.zip $DOWNLOAD_URL
+    curl -fLO https://github.com/elixir-lsp/elixir-ls/releases/latest/download/elixir-ls.zip
     unzip elixir-ls.zip
     chmod +x language_server.sh
     rm -f elixir-ls.zip
   ]],
-  default_config = {
-    cmd = { "./language_server.sh" }
-  }
 })

--- a/lua/lspinstall/servers/elixir.lua
+++ b/lua/lspinstall/servers/elixir.lua
@@ -1,0 +1,15 @@
+local config = require'lspconfig'.elixirls.document_config
+require'lspconfig/configs'.elixirls = nil -- important, immediately unset the loaded config again
+
+return vim.tbl_extend('error', config, {
+  install_script = [[
+    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/elixir-lsp/elixir-ls/releases/latest | grep 'browser' | grep 'elixir-ls.zip' | cut -d '"' -f4)
+    curl -L -o elixir-ls.zip $DOWNLOAD_URL
+    unzip elixir-ls.zip
+    chmod +x language_server.sh
+    rm -f elixir-ls.zip
+  ]],
+  default_config = {
+    cmd = { "./language_server.sh" }
+  }
+})


### PR DESCRIPTION
Due to the way that [elixir-ls works in nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#elixirls), I could not set `cmd` on the file, so the installation is currently working and the user needs to set elixirls's `cmd` as `/home/<user>/.local/share/nvim/lspinstall/elixir/language_server.sh` on setup in order to the language server to start. I wonder if we can improve this and make it work out of the box or just add documentation about that issue.
