### PR TITLE
Fix eelixir filetype detection for tailwindcss

### DIFF
--- a/lua/lspinstall/servers/tailwindcss.lua
+++ b/lua/lspinstall/servers/tailwindcss.lua
@@ -18,6 +18,7 @@ return {
       'blade',
       'django-html',
       'edge',
+      'eelixir',
       'ejs',
       'eruby',
       'gohtml',
@@ -59,6 +60,7 @@ return {
     },
     init_options = {
       userLanguages = {
+        eelixir = "html-eex",
         eruby = "html"
       }
     },


### PR DESCRIPTION
This PR fixes the file type detection of `eelixir` files by adding a new entry to `userLanguages`, similar to the fix for `eruby`. This allows for both Elixir and TailwindCSS language servers to attach to `*.html.*eex` buffers, e.g. a Phoenix Live View template.