### PR TITLE
add kotlin-language-server support (#48) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ end
 | graphql     | GraphQL language service                                                    |
 | html        | html-language-features (pulled directly from the latest VSCode release)     |
 | json        | json-language-features (pulled directly from the latest VSCode release)     |
+| Kotlin      | kotlin-language-server                                                      |
 | latex       | texlab                                                                      |
 | lua         | (sumneko) lua-language-server                                               |
 | php         | intelephense                                                                |
@@ -104,7 +105,7 @@ Here `config` is a LSP config for [nvim-lspconfig](https://github.com/neovim/nvi
 The following example provides an installer for `bash-language-server`.
 ```lua
 -- 1. get the default config from nvim-lspconfig
-local config = require"lspinstall/util".extract_config("bashls") 
+local config = require"lspinstall/util".extract_config("bashls")
 -- 2. update the cmd. relative paths are allowed, lspinstall automatically adjusts the cmd and cmd_cwd for us!
 config.default_config.cmd[1] = "./node_modules/.bin/bash-language-server"
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ end
 | graphql     | GraphQL language service                                                    |
 | html        | html-language-features (pulled directly from the latest VSCode release)     |
 | json        | json-language-features (pulled directly from the latest VSCode release)     |
-| Kotlin      | kotlin-language-server                                                      |
+| kotlin      | kotlin-language-server                                                      |
 | latex       | texlab                                                                      |
 | lua         | (sumneko) lua-language-server                                               |
 | php         | intelephense                                                                |

--- a/lua/lspinstall/servers.lua
+++ b/lua/lspinstall/servers.lua
@@ -15,6 +15,7 @@ local servers = {
   ["graphql"] = require'lspinstall/servers/graphql',
   ["html"] = require'lspinstall/servers/html',
   ["json"] = require'lspinstall/servers/json',
+  ["kotlin"] = require'lspinstall/servers/kotlin',
   ["latex"] = require'lspinstall/servers/latex',
   ["lua"] = require'lspinstall/servers/lua',
   ["php"] = require'lspinstall/servers/php',

--- a/lua/lspinstall/servers/elixir.lua
+++ b/lua/lspinstall/servers/elixir.lua
@@ -3,10 +3,10 @@ config.default_config.cmd = { "./elixir-ls/language_server.sh" }
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-    rm -rf elixir-ls
     curl -fLO https://github.com/elixir-lsp/elixir-ls/releases/latest/download/elixir-ls.zip
+    rm -rf elixir-ls
     unzip elixir-ls.zip -d elixir-ls
-    chmod +x elixir-ls/language_server.sh
     rm elixir-ls.zip
+    chmod +x elixir-ls/language_server.sh
   ]],
 })

--- a/lua/lspinstall/servers/kotlin.lua
+++ b/lua/lspinstall/servers/kotlin.lua
@@ -11,10 +11,11 @@ return vim.tbl_extend(
 
   unzip kotlin.zip
   rm kotlin.zip
-  mv server kotlin-language-server
+  mv server/* .
+  rmdir server
 
-  if [ ! -x ./kotlin-language-server/bin/kotlin-language-server ]; then
-    chmod +x ./kotlin-language-server/bin/kotlin-language-server
+  if [ ! -x ./bin/kotlin-language-server ]; then
+    chmod +x ./bin/kotlin-language-server
   fi
   ]]
     }

--- a/lua/lspinstall/servers/kotlin.lua
+++ b/lua/lspinstall/servers/kotlin.lua
@@ -1,22 +1,12 @@
 local config = require "lspinstall/util".extract_config("kotlin_language_server")
-config.default_config.cmd[1] = "./bin/kotlin-language-server"
+config.default_config.cmd[1] = "./server/bin/kotlin-language-server"
 
-return vim.tbl_extend(
-    "error",
-    config,
-    {
-        install_script = [[
-  url=$(curl -s https://api.github.com/repos/fwcd/kotlin-language-server/releases/latest | grep browser_ | cut -d\" -f4 | grep server.zip)
-  curl -L -o "kotlin.zip" "$url"
-
-  unzip kotlin.zip
-  rm kotlin.zip
-  mv server/* .
-  rmdir server
-
-  if [ ! -x ./bin/kotlin-language-server ]; then
-    chmod +x ./bin/kotlin-language-server
-  fi
+return vim.tbl_extend("error", config, {
+  install_script = [[
+    curl -fLO https://github.com/fwcd/kotlin-language-server/releases/latest/download/server.zip
+    rm -rf server
+    unzip server.zip
+    rm server.zip
+    chmod +x server/bin/kotlin-language-server
   ]]
-    }
-)
+})

--- a/lua/lspinstall/servers/kotlin.lua
+++ b/lua/lspinstall/servers/kotlin.lua
@@ -1,5 +1,5 @@
 local config = require "lspinstall/util".extract_config("kotlin_language_server")
-config.default_config.cmd[1] = "./kotlin-language-server/bin/kotlin-language-server"
+config.default_config.cmd[1] = "./bin/kotlin-language-server"
 
 return vim.tbl_extend(
     "error",

--- a/lua/lspinstall/servers/kotlin.lua
+++ b/lua/lspinstall/servers/kotlin.lua
@@ -1,0 +1,21 @@
+local config = require "lspinstall/util".extract_config("kotlin_language_server")
+config.default_config.cmd[1] = "./kotlin-language-server/bin/kotlin-language-server"
+
+return vim.tbl_extend(
+    "error",
+    config,
+    {
+        install_script = [[
+  url=$(curl -s https://api.github.com/repos/fwcd/kotlin-language-server/releases/latest | grep browser_ | cut -d\" -f4 | grep server.zip)
+  curl -L -o "kotlin.zip" "$url"
+
+  unzip kotlin.zip
+  rm kotlin.zip
+  mv server kotlin-language-server
+
+  if [ ! -x ./kotlin-language-server/bin/kotlin-language-server ]; then
+    chmod +x ./kotlin-language-server/bin/kotlin-language-server
+  fi
+  ]]
+    }
+)


### PR DESCRIPTION
Can someone test this ? it's working for me. 

Also is important to note that kotlin language server will only work with java installed and certain environment variables set like `JAVA_HOME`. But of course this goes out of the scope of this and should be left to the user, although it may be a good idea to add that information to the README for people with minimal systems (Arch, Gentoo, etc) and thus don't come with java installed by default. This way those people are aware of what they need to do in order for the server to work.    