### PR TITLE
Add zig language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ end
 | vim         | vim-language-server                                                         |
 | vue         | vls (vetur)                                                                 |
 | yaml        | yaml-language-server                                                        |
+| zig         | zig-language-server (zls)                                                   |
 
 | Name        | Description                                                                 |
 |-------------|-----------------------------------------------------------------------------|

--- a/lua/lspinstall/servers.lua
+++ b/lua/lspinstall/servers.lua
@@ -29,6 +29,7 @@ local servers = {
   ["vim"] = require'lspinstall/servers/vim',
   ["vue"] = require'lspinstall/servers/vue',
   ["yaml"] = require'lspinstall/servers/yaml',
+  ["zig"] = require'lspinstall/servers/zig',
 }
 
 return servers

--- a/lua/lspinstall/servers/zig.lua
+++ b/lua/lspinstall/servers/zig.lua
@@ -1,0 +1,15 @@
+local config = require"lspinstall/util".extract_config("zls")
+config.default_config.cmd[1] = "./zls/zig-out/bin/zls"
+
+return vim.tbl_extend("error", config, {
+    install_script = [[
+    #!/usr/bin/env bash
+
+    rm -rf zls
+    git clone --recurse-submodules https://github.com/zigtools/zls
+    cd zls
+    zig build -Drelease-safe
+    # Generate the zls config enabling all the features
+    ./zig-out/bin/zls config
+    ]]
+})


### PR DESCRIPTION
Zig (master) is required to compile zls since the released binaries are outdated and don't work with the latest (master) versions of Zig.
Also, the config will ask if you want the config system-wide, but that will likely not work. It requires root permissions, at least it does on my system, so setting it to "no" is forced.