### PR TITLE
Fix graphql-lsp

### DIFF
--- a/lua/lspinstall/servers/graphql.lua
+++ b/lua/lspinstall/servers/graphql.lua
@@ -4,6 +4,6 @@ config.default_config.cmd[1] = "./node_modules/.bin/graphql-lsp"
 return vim.tbl_extend('error', config, {
   install_script = [[
   ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install graphql-language-service-cli@latest
+  npm install graphql graphql-language-service-cli@latest
   ]]
 })


### PR DESCRIPTION
graphql-lsp binary needs the graphql package in order to execute, otherwise it throws "Error: Cannot find module 'graphql'"