### PR TITLE
Adds 'die' function to jdtls.sh

### DIFF
--- a/lua/lspinstall/servers/java.lua
+++ b/lua/lspinstall/servers/java.lua
@@ -88,6 +88,13 @@ cat << EOF > jdtls.sh
 
 WORKSPACE="\$1"
 
+die () {
+  echo
+  echo "$*"
+  echo
+  exit 1
+}
+
 case $(uname) in
   Linux)
     CONFIG="$(pwd)/config_linux"


### PR DESCRIPTION
As discussed in #65, the `jdtls.sh` script calls an undefined function `die` in lines that were taken from another script. This PR adds that function, so that `jdtls.sh` can die more gracefully :)