### PR TITLE
Update path to bash to use /usr/bin/env

### DIFF
--- a/lua/lspinstall.lua
+++ b/lua/lspinstall.lua
@@ -64,7 +64,7 @@ function M.uninstall_server(lang)
 
   vim.cmd("new")
   local shell = vim.o.shell
-  vim.o.shell = '/bin/bash'
+  vim.o.shell = '/usr/bin/env bash'
   vim.fn.termopen("set -e\n" .. (servers[lang].uninstall_script or ""), {["cwd"] = path, ["on_exit"] = onExit})
   vim.o.shell = shell
   vim.cmd("startinsert")


### PR DESCRIPTION
Many other UNIX operating systems don't use /bin/bash, but rather /usr/local/bin/bash. Calling /usr/bin/env first is always smart.