### PR TITLE
Use Rust standard target name (aarch64) for arm64

### DIFF
--- a/lua/lspinstall/servers/rust.lua
+++ b/lua/lspinstall/servers/rust.lua
@@ -7,6 +7,10 @@ return vim.tbl_extend('error', config, {
   os=$(uname -s | tr "[:upper:]" "[:lower:]")
   mchn=$(uname -m | tr "[:upper:]" "[:lower:]")
 
+  if [ $mchn = "arm64" ]; then
+    mchn="aarch64"
+  fi
+
   case $os in
   linux)
   platform="unknown-linux-gnu"


### PR DESCRIPTION
The download [link locations](https://github.com/rust-analyzer/rust-analyzer/releases) for `rust-analyzer` are `aarch64` prefixed, while `uname -m` will return `arm64`. This fixes that so that the `rust-analyzer` will work on `arm64` machines.

Tested to work on my M1 Mac, whereas the current implementation misses the link.