### PR TITLE
tailwindcss: Extract from lspconfig and use npm package

### DIFF
--- a/lua/lspinstall/servers/tailwindcss.lua
+++ b/lua/lspinstall/servers/tailwindcss.lua
@@ -1,104 +1,16 @@
-local util = require"lspconfig".util
-return {
+local config = require"lspinstall/util".extract_config("tailwindcss")
+config.default_config.cmd[1] = "./tailwindcss-language-server"
+
+return vim.tbl_extend('error', config, {
   install_script = [[
   curl -L -o tailwindcss-intellisense.vsix $(curl -s https://api.github.com/repos/tailwindlabs/tailwindcss-intellisense/releases/latest | grep 'browser_' | cut -d\" -f4)
   rm -rf tailwindcss-intellisense
   unzip tailwindcss-intellisense.vsix -d tailwindcss-intellisense
   rm tailwindcss-intellisense.vsix
 
-  echo "#!/usr/bin/env bash" > tailwindcss-intellisense.sh
-  echo "node \$(dirname \$0)/tailwindcss-intellisense/extension/dist/server/tailwindServer.js \$*" >> tailwindcss-intellisense.sh
+  echo "#!/usr/bin/env bash" > tailwindcss-language-server
+  echo "node \$(dirname \$0)/tailwindcss-intellisense/extension/dist/server/tailwindServer.js \$*" >> tailwindcss-language-server
 
-  chmod +x tailwindcss-intellisense.sh
+  chmod +x tailwindcss-language-server
   ]],
-  default_config = {
-    cmd = { "node", "./tailwindcss-intellisense/extension/dist/server/tailwindServer.js", "--stdio" },
-    -- filetypes copied and adjusted from tailwindcss-intellisense
-    filetypes = {
-      -- html
-      'aspnetcorerazor',
-      'astro',
-      'astro-markdown',
-      'blade',
-      'django-html',
-      'edge',
-      'eelixir', -- vim ft
-      'ejs',
-      'erb',
-      'eruby', -- vim ft
-      'gohtml',
-      'haml',
-      'handlebars',
-      'hbs',
-      'html',
-      -- 'HTML (Eex)',
-      -- 'HTML (EEx)',
-      'html-eex',
-      'jade',
-      'leaf',
-      'liquid',
-      'markdown',
-      'mdx',
-      'mustache',
-      'njk',
-      'nunjucks',
-      'php',
-      'razor',
-      'slim',
-      'twig',
-      -- css
-      'css',
-      'less',
-      'postcss',
-      'sass',
-      'scss',
-      'stylus',
-      'sugarss',
-      -- js
-      'javascript',
-      'javascriptreact',
-      'reason',
-      'rescript',
-      'typescript',
-      'typescriptreact',
-      -- mixed
-      'vue',
-      'svelte',
-    },
-    init_options = {
-      userLanguages = {
-        eelixir = 'html-eex',
-        eruby = 'erb',
-      }
-    },
-    settings = {
-      tailwindCSS = {
-        validate = true,
-        lint = {
-          cssConflict = "warning",
-          invalidApply = "error",
-          invalidScreen = "error",
-          invalidVariant = "error",
-          invalidConfigPath = "error",
-          invalidTailwindDirective = "error",
-          recommendedVariantOrder = "warning",
-        },
-      },
-    },
-    on_new_config = function(new_config)
-      if not new_config.settings then new_config.settings = {} end
-      if not new_config.settings.editor then new_config.settings.editor = {} end
-      if not new_config.settings.editor.tabSize then
-        -- set tab size for hover
-        new_config.settings.editor.tabSize = vim.lsp.util.get_effective_tabstop()
-      end
-    end,
-    root_dir = function(fname)
-      return util.root_pattern('tailwind.config.js', 'tailwind.config.ts')(fname) or
-      util.root_pattern('postcss.config.js', 'postcss.config.ts')(fname) or
-      util.find_package_json_ancestor(fname) or
-      util.find_node_modules_ancestor(fname) or
-      util.find_git_ancestor(fname)
-    end,
-  }
-}
+})

--- a/lua/lspinstall/servers/tailwindcss.lua
+++ b/lua/lspinstall/servers/tailwindcss.lua
@@ -1,16 +1,9 @@
 local config = require"lspinstall/util".extract_config("tailwindcss")
-config.default_config.cmd[1] = "./tailwindcss-language-server"
+config.default_config.cmd[1] = "./node_modules/.bin/tailwindcss-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  curl -L -o tailwindcss-intellisense.vsix $(curl -s https://api.github.com/repos/tailwindlabs/tailwindcss-intellisense/releases/latest | grep 'browser_' | cut -d\" -f4)
-  rm -rf tailwindcss-intellisense
-  unzip tailwindcss-intellisense.vsix -d tailwindcss-intellisense
-  rm tailwindcss-intellisense.vsix
-
-  echo "#!/usr/bin/env bash" > tailwindcss-language-server
-  echo "node \$(dirname \$0)/tailwindcss-intellisense/extension/dist/server/tailwindServer.js \$*" >> tailwindcss-language-server
-
-  chmod +x tailwindcss-language-server
-  ]],
+  ! test -f package.json && npm init -y --scope=lspinstall || true
+  npm install @tailwindcss/language-server
+  ]]
 })


### PR DESCRIPTION
- The config was imported into lspconfig 🎉:
  https://github.com/neovim/nvim-lspconfig/pull/966

- Follow upstream naming for the standalone server:
  https://github.com/tailwindlabs/tailwindcss-intellisense/blob/c01fed9c9fc3423f85df130aab001c220af68b7c/packages/tailwindcss-language-server/package.json#L6-L8

PS: This now creates a standalone `tailwindcss-language-server` executable instead of a wrapper, as upstream does. Please let me know if you want to stick with the wrapper.