### PR TITLE
(needs a code review) added the emmet lsp from aca/emmet-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ end
 | dockerfile  | docker-langserver                                                           |
 | elixir      | Elixir Language Server (elixir-ls)                                          |
 | elm         | Elm Language Server (elm-ls)                                                |
+| emmet       | aca/Emmet-ls                                                                |
 | go          | gopls                                                                       |
 | graphql     | GraphQL language service                                                    |
 | html        | html-language-features (pulled directly from the latest VSCode release)     |

--- a/lua/lspinstall/servers/emmet.lua
+++ b/lua/lspinstall/servers/emmet.lua
@@ -1,0 +1,11 @@
+-- reference
+-- https://github.com/aca/emmet-ls
+local config = require"lspinstall/util".extract_config("emmet")
+config.default_config.cmd[1] = "./node_modules/.bin/emmet-ls"
+
+return vim.tbl_extend('error', config, {
+    install_script = [[
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install emmet-ls
+    ]]
+})


### PR DESCRIPTION
Hi,

I'd like to add emmet to the list of supported languages by the plugin. I have created emmet.lua which is an npm install from this [repo](https://github.com/aca/emmet-ls).

I have it running on my system but using the [lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#elmls) method. I am a bit confused as to how it all work since I drew inspiration from other lsp servers in the plugin.

Needs a review, Thank you