### PR TITLE
fix: support single java file

### DIFF
--- a/lua/lspinstall/servers/java.lua
+++ b/lua/lspinstall/servers/java.lua
@@ -44,7 +44,8 @@ return {
         local root = util.root_pattern(unpack(patterns))(...)
         if root then return root end
       end
-      return util.root_pattern(".git")(...)
+      -- If the root_pattern, does not match, use the current directory instead
+      return vim.fn.getcwd()
     end,
     init_options = {
       workspace = path.join { vim.loop.os_homedir(), "workspace" },


### PR DESCRIPTION
Add support for single java file.

refer: https://github.com/neovim/nvim-lspconfig/blob/48e47b4d26e45977d27c06dc1bc116416ca9276d/lua/lspconfig/jdtls.lua#L82