### PR TITLE
fix: move javaagent and Xbootclasspath args before jar arg

### DIFF
--- a/lua/lspinstall/servers/java.lua
+++ b/lua/lspinstall/servers/java.lua
@@ -136,14 +136,14 @@ fi
   -Dlog.level=ALL \\
   -Xms1g \\
   -Xmx2G \\
+  -javaagent:$(pwd)/lombok.jar \\
+  -Xbootclasspath/a:$(pwd)/lombok.jar \\
   -jar \$(echo "\$JAR") \\
   -configuration "\$CONFIG" \\
   -data "\$WORKSPACE" \\
   --add-modules=ALL-SYSTEM \\
   --add-opens java.base/java.util=ALL-UNNAMED \\
-  --add-opens java.base/java.lang=ALL-UNNAMED \\
-  -javaagent:$(pwd)/lombok.jar \\
-  -Xbootclasspath/a:$(pwd)/lombok.jar
+  --add-opens java.base/java.lang=ALL-UNNAMED
 EOF
     chmod +x jdtls.sh
   ]],


### PR DESCRIPTION
In order for LSP to properly recognize Lombok and all of it's annotations, the `javagent` and `xbootclasspath` arguments need to be before the `jar` argument per this comment: https://github.com/mfussenegger/nvim-jdtls/issues/28#issuecomment-759175972

I was able to confirm that this resolved the issue for `openjdk8` to `openjdk@14`. LSP now correctly recognizes the Lombok annotations and no longer shows warning/errors (for example for the `@Getter` and `@Setter` annotations).