### PR TITLE
yaml: loading of users bash profile

### DIFF
--- a/lua/lspinstall/servers/yaml.lua
+++ b/lua/lspinstall/servers/yaml.lua
@@ -3,7 +3,7 @@ config.default_config.cmd[1] = "./node_modules/.bin/yaml-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f ~/.profile && source ~/.profile
+  test -f ~/.bashrc && source ~/.bashrc
   ! test -f package.json && yarn init -y  || true
   yarn add yaml-language-server@latest
   ]]

--- a/lua/lspinstall/servers/yaml.lua
+++ b/lua/lspinstall/servers/yaml.lua
@@ -3,6 +3,7 @@ config.default_config.cmd[1] = "./node_modules/.bin/yaml-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
+  ! test -f ~/.profile && source ~/.profile
   ! test -f package.json && yarn init -y  || true
   yarn add yaml-language-server@latest
   ]]


### PR DESCRIPTION
Heya, new lsp user here

If a user has `fnm` or `nvm` I noticed this thing fails to detect the path to yarn.

That is because the bash script being run does not load the users actual environment (its probably running in non-interactive mode also)

I'm thinking generally that this codebase should possibly be clever with how it detects a users environment
- not all users will export things like fnm/nvm correctly
- users may accidentally export them in their shells only for interactive sessions
- This does not respect the users existing environment or shell (fish+zsh user here), if it did it would have no issue finding yarn
- its super hard to know what files to source for even just bash eg: `~/.bashrc`, `~/.profile`, `~/.bash_profile` 

I'm thinking about how to solve this more gracefully and happy to volunteer to write some fish for you

In this PR I initially loaded my `~/.profile` (its common between my `~/.zshrc` and `~/.bashrc` and loads stuff like `fnm` or `nvm`) however after looking at the `nvm` docs I think most users will have their bash nvm stuff in `~/.bashrc`