### PR TITLE
Moved add-opens and add-modules before jar

### DIFF
--- a/lua/lspinstall/servers/java.lua
+++ b/lua/lspinstall/servers/java.lua
@@ -138,12 +138,12 @@ fi
   -Xmx2G \\
   -javaagent:$(pwd)/lombok.jar \\
   -Xbootclasspath/a:$(pwd)/lombok.jar \\
-  -jar \$(echo "\$JAR") \\
-  -configuration "\$CONFIG" \\
-  -data "\$WORKSPACE" \\
   --add-modules=ALL-SYSTEM \\
   --add-opens java.base/java.util=ALL-UNNAMED \\
-  --add-opens java.base/java.lang=ALL-UNNAMED
+  --add-opens java.base/java.lang=ALL-UNNAMED \\
+  -jar \$(echo "\$JAR") \\
+  -configuration "\$CONFIG" \\
+  -data "\$WORKSPACE"
 EOF
     chmod +x jdtls.sh
   ]],


### PR DESCRIPTION
Avoids this exception

```java
java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @25754cd1
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.overrideLoadResult(ModuleClassLoader.java:86)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
	at org.eclipse.jdt.internal.compiler.parser.Parser.consumeExitVariableWithInitialization(Parser.java:4163)
	at org.eclipse.jdt.internal.compiler.SourceElementParser.consumeExitVariableWithInitialization(SourceElementParser.java:406)
	at org.eclipse.jdt.internal.compiler.parser.Parser.consumeRule(Parser.java:7116)
	at org.eclipse.jdt.internal.compiler.parser.Parser.parse(Parser.java:12920)
	at org.eclipse.jdt.internal.compiler.parser.Parser.parse(Parser.java:13175)
	at org.eclipse.jdt.internal.compiler.parser.Parser.parse(Parser.java:13132)
	at org.eclipse.jdt.internal.compiler.SourceElementParser.parseCompilationUnit(SourceElementParser.java:1122)
	at org.eclipse.jdt.internal.core.CompilationUnit.buildStructure(CompilationUnit.java:196)
	at org.eclipse.jdt.internal.core.Openable.generateInfos(Openable.java:266)
	at org.eclipse.jdt.internal.core.JavaElement.openWhenClosed(JavaElement.java:600)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:330)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:316)
	at org.eclipse.jdt.internal.core.Openable.getBuffer(Openable.java:296)
	at org.eclipse.jdt.ls.core.internal.handlers.CompletionHandler.computeContentAssist(CompletionHandler.java:111)
	at org.eclipse.jdt.ls.core.internal.handlers.CompletionHandler.completion(CompletionHandler.java:79)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$5(JDTLanguageServer.java:522)
	at org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer.lambda$0(BaseJDTLanguageServer.java:75)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:479)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:295)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1016)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)