### PR TITLE
Pass the jid to post_install_hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Note: **don't** replace the `/` with a `.` in the `require` calls above ([see he
 * `require'lspinstall'.installed_servers()`
 
 * `require'lspinstall'.install_server(<lang>)`
-* `require'lspinstall'.post_install_hook`
+* `require'lspinstall'.post_install_hook(<jid>)`
 
 * `require'lspinstall'.uninstall_server(<lang>)`
 * `require'lspinstall'.post_uninstall_hook`

--- a/lua/lspinstall.lua
+++ b/lua/lspinstall.lua
@@ -12,7 +12,7 @@ function M.install_server(lang)
   local path = install_path(lang)
   vim.fn.mkdir(path, "p") -- fail: throws
 
-  local function onExit(_, code)
+  local function onExit(jid, code)
     if code ~= 0 then
       if vim.fn.delete(path, "rf") ~= 0 then -- here 0: success, -1: fail
         error("[nvim-lspinstall] Could not delete directory " .. lang)
@@ -20,7 +20,7 @@ function M.install_server(lang)
       error("[nvim-lspinstall] Could not install language server for " .. lang)
     end
     vim.notify("[nvim-lspinstall] Successfully installed language server for " .. lang)
-    if M.post_install_hook then M.post_install_hook() end
+    if M.post_install_hook then M.post_install_hook(jid) end
   end
 
   vim.cmd("new")


### PR DESCRIPTION
This will enable users to handle the windows opened to run the jobs,

```lua
require'lspinstall'.post_install_hook = function(jid)
  local channel_info = vim.api.nvim_get_chan_info(jid)
  local winid = vim.fn.bufwinid(channel_info.buffer)
  vim.api.nvim_win_close(winid, true)
end
```
