### PR TITLE
delete the lang server directory if installation fails

### DIFF
--- a/lua/lspinstall.lua
+++ b/lua/lspinstall.lua
@@ -13,7 +13,10 @@ function M.install_server(lang)
   vim.fn.mkdir(path, "p") -- fail: throws
 
   local function onExit(_, code)
-    if code ~= 0 then error("[nvim-lspinstall] Could not install language server for " .. lang) end
+    if code ~= 0 then
+			vim.fn.delete(path, "rf")
+			error("[nvim-lspinstall] Could not install language server for " .. lang)
+		end
     vim.notify("[nvim-lspinstall] Successfully installed language server for " .. lang)
     if M.post_install_hook then M.post_install_hook() end
   end


### PR DESCRIPTION
Hi,

This PR uses the vim.fn.delete function to remove a directory if the code returned from the terminal when installing a language server is different from 0. It aims to address [this issue](https://github.com/kabouzeid/nvim-lspinstall/issues/129).