### PR TITLE
fix(tailwindcss): escape sha-bang

### DIFF
--- a/lua/lspinstall/servers/tailwindcss.lua
+++ b/lua/lspinstall/servers/tailwindcss.lua
@@ -6,7 +6,7 @@ return {
   unzip tailwindcss-intellisense.vsix -d tailwindcss-intellisense
   rm tailwindcss-intellisense.vsix
 
-  echo "#!/usr/bin/env bash" > tailwindcss-intellisense.sh
+  echo "#\!/usr/bin/env bash" > tailwindcss-intellisense.sh
   echo "node \$(dirname \$0)/tailwindcss-intellisense/extension/dist/server/tailwindServer.js \$*" >> tailwindcss-intellisense.sh
 
   chmod +x tailwindcss-intellisense.sh


### PR DESCRIPTION
Hello,

I found a bug while trying to install tailwindcss.

When you inject the sha-bang to tailwindcss-intellisense.sh, the exclamation mark is misinterpreted by the terminal and it tries to execute the command.