### PR TITLE
delete lang dir before throwing error

### DIFF
--- a/lua/lspinstall.lua
+++ b/lua/lspinstall.lua
@@ -14,10 +14,10 @@ function M.install_server(lang)
 
   local function onExit(_, code)
     if code ~= 0 then
-      error("[nvim-lspinstall] Could not install language server for " .. lang)
       if vim.fn.delete(path, "rf") ~= 0 then -- here 0: success, -1: fail
         error("[nvim-lspinstall] Could not delete directory " .. lang)
       end
+      error("[nvim-lspinstall] Could not install language server for " .. lang)
     end
     vim.notify("[nvim-lspinstall] Successfully installed language server for " .. lang)
     if M.post_install_hook then M.post_install_hook() end


### PR DESCRIPTION
Hi,

This PR moves the line that throws an error when a language server is not properly installed to ensure that the create language server's directory is deleted on a failed install.