### PR TITLE
rust: use already installed server if found

### DIFF
--- a/lua/lspinstall/servers/rust.lua
+++ b/lua/lspinstall/servers/rust.lua
@@ -26,7 +26,7 @@ return vim.tbl_extend('error', config, {
 
     mv rust-analyzer-$mchn-$platform rust-analyzer
   else
-    ln "$PREFIX/bin/rust-analyzer" rust-analyzer
+    ln -s "$PREFIX/bin/rust-analyzer" rust-analyzer
   fi
 
   chmod +x rust-analyzer

--- a/lua/lspinstall/servers/rust.lua
+++ b/lua/lspinstall/servers/rust.lua
@@ -4,26 +4,30 @@ config.default_config.cmd[1] = "./rust-analyzer"
 return vim.tbl_extend('error', config, {
   -- adjusted from https://github.com/mattn/vim-lsp-settings/blob/master/installer/install-rust-analyzer.sh
   install_script = [[
-  os=$(uname -s | tr "[:upper:]" "[:lower:]")
-  mchn=$(uname -m | tr "[:upper:]" "[:lower:]")
+  if ! [ -e "$PREFIX/bin/rust-analyzer"]; then
+    os=$(uname -s | tr "[:upper:]" "[:lower:]")
+    mchn=$(uname -m | tr "[:upper:]" "[:lower:]")
 
-  if [ $mchn = "arm64" ]; then
-    mchn="aarch64"
+    if [ $mchn = "arm64" ]; then
+      mchn="aarch64"
+    fi
+  
+    case $os in
+    linux)
+    platform="unknown-linux-gnu"
+    ;;
+    darwin)
+    platform="apple-darwin"
+    ;;
+    esac
+
+    curl -L -o "rust-analyzer-$mchn-$platform.gz" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-$mchn-$platform.gz"
+    gzip -d rust-analyzer-$mchn-$platform.gz
+
+    mv rust-analyzer-$mchn-$platform rust-analyzer
+  else
+    ln "$PREFIX/bin/rust-analyzer" rust-analyzer
   fi
-
-  case $os in
-  linux)
-  platform="unknown-linux-gnu"
-  ;;
-  darwin)
-  platform="apple-darwin"
-  ;;
-  esac
-
-  curl -L -o "rust-analyzer-$mchn-$platform.gz" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-$mchn-$platform.gz"
-  gzip -d rust-analyzer-$mchn-$platform.gz
-
-  mv rust-analyzer-$mchn-$platform rust-analyzer
 
   chmod +x rust-analyzer
   ]]


### PR DESCRIPTION
I was trying to install rust-analyzer on my Android machine on Termux, and Termux requires a specially compiled version of it (along with every other package), which makes the method of downloading from the release not viable. The other way is to soft-link an already existing binary from `$PREFIX/bin`, where Termux packages' binaries are stored.

I don't think it'd be very efficient to completely copy the binary, so I decided to use a symlink.