### PR TITLE
Add installer for D language (dlang) that uses serve-d 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ end
 | cpp         | clangd                                                                      |
 | csharp      | OmniSharp                                                                   |
 | css         | css-language-features (pulled directly from the latest VSCode release)      |
+| dlang       | serve-d                                                          |
 | dockerfile  | docker-langserver                                                           |
 | elixir      | Elixir Language Server (elixir-ls)                                          |
 | elm         | Elm Language Server (elm-ls)                                                |

--- a/lua/lspinstall/servers.lua
+++ b/lua/lspinstall/servers.lua
@@ -8,6 +8,7 @@ local servers = {
   ["css"] = require'lspinstall/servers/css',
   ["deno"] = require'lspinstall/servers/deno',
   ["diagnosticls"] = require'lspinstall/servers/diagnosticls',
+  ["dlang"] = require'lspinstall/servers/dlang',
   ["dockerfile"] = require'lspinstall/servers/dockerfile',
   ["efm"] = require'lspinstall/servers/efm',
   ["elixir"] = require'lspinstall/servers/elixir',

--- a/lua/lspinstall/servers/dlang.lua
+++ b/lua/lspinstall/servers/dlang.lua
@@ -1,0 +1,23 @@
+local config = require"lspinstall/util".extract_config("serve_d")
+config.default_config.cmd = { "./serve-d" }
+
+return vim.tbl_extend('error', config, {
+  -- Install serve-d from https://github.com/Pure-D/serve-d
+  install_script = [[
+  os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+  case $os in
+  linux)
+  platform="linux"
+  ;;
+  darwin)
+  platform="osx"
+  ;;
+  esac
+
+  curl -L -o serve-d.tar.xz $(curl -s https://api.github.com/repos/Pure-D/serve-d/releases | grep 'browser_' |  cut -d\" -f4 | grep "$platform" | head -1 | grep '.tar.xz')
+  tar xf serve-d.tar.xz
+  rm -f serve-d.tar.xz
+  chmod +x serve-d
+  ]]
+})


### PR DESCRIPTION
.. from https://github.com/Pure-D/serve-d

# PLEASE READ BEFORE CREATING THE PR :)

## For new install scripts

You need to create one file, and edit two files. See this PR for a good example: https://github.com/kabouzeid/nvim-lspinstall/pull/106/files

Whenever possible, use `local config = require'lspinstall/util'.extract_config('rust_analyzer')` to extract the config for your language server from [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).
If they don't have a config for your language server yet, please create a pull request there first.
Don't worry, they are usually quite fast with merging new configs.
