### PR TITLE
feat(julia): add julia to list of installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ end
 | html        | html-language-features (pulled directly from the latest VSCode release)     |
 | java        | Eclipse JDTLS with Lombok                                                   |
 | json        | json-language-features (pulled directly from the latest VSCode release)     |
+| julia       | LanguageServer.jl                                                           |
 | kotlin      | kotlin-language-server                                                      |
 | latex       | texlab                                                                      |
 | lua         | (sumneko) lua-language-server                                               |

--- a/lua/lspinstall/servers.lua
+++ b/lua/lspinstall/servers.lua
@@ -20,6 +20,7 @@ local servers = {
   ["html"] = require'lspinstall/servers/html',
   ["java"] = require'lspinstall/servers/java',
   ["json"] = require'lspinstall/servers/json',
+  ["julia"] = require'lspinstall/servers/julia',
   ["kotlin"] = require'lspinstall/servers/kotlin',
   ["latex"] = require'lspinstall/servers/latex',
   ["lua"] = require'lspinstall/servers/lua',

--- a/lua/lspinstall/servers/julia.lua
+++ b/lua/lspinstall/servers/julia.lua
@@ -1,0 +1,19 @@
+return {
+  install_script = [[
+  os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+  case $os in
+  linux)
+  platform="linux"
+  ;;
+  darwin)
+  platform="macos"
+  ;;
+  esac
+
+  julia --project=~/.julia/environments/nvim-lspconfig -e 'using Pkg; Pkg.add("LanguageServer")'
+  ]],
+  default_config = {
+    filetypes = { 'julia'},
+  }
+}


### PR DESCRIPTION
Install the Julia Language Server using the Julia Package Manager to the path expected by nvim-lspconfig [default](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#julials).

Cheers