### PR TITLE
🧶 Yarn Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ end
 | json        | json-language-features (pulled directly from the latest VSCode release)     |
 | kotlin      | kotlin-language-server                                                      |
 | latex       | texlab                                                                      |
+| lemminx     | xml language server                                                         |
 | lua         | (sumneko) lua-language-server                                               |
 | php         | intelephense                                                                |
 | prisma      | prisma-language-server                                                      |

--- a/lua/lspinstall/servers.lua
+++ b/lua/lspinstall/servers.lua
@@ -22,6 +22,7 @@ local servers = {
   ["json"] = require'lspinstall/servers/json',
   ["kotlin"] = require'lspinstall/servers/kotlin',
   ["latex"] = require'lspinstall/servers/latex',
+  ["lemminx"] = require'lspinstall/servers/lemminx',
   ["lua"] = require'lspinstall/servers/lua',
   ["php"] = require'lspinstall/servers/php',
   ["prismals"] = require'lspinstall/servers/prismals',

--- a/lua/lspinstall/servers/angular.lua
+++ b/lua/lspinstall/servers/angular.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/ngserver"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install @angular/language-server
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add @angular/language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install @angular/language-server
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/bash.lua
+++ b/lua/lspinstall/servers/bash.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/bash-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install bash-language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add bash-language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install bash-language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/diagnosticls.lua
+++ b/lua/lspinstall/servers/diagnosticls.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/diagnostic-languageserver"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install diagnostic-languageserver@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add diagnostic-languageserver@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install diagnostic-languageserver@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/dockerfile.lua
+++ b/lua/lspinstall/servers/dockerfile.lua
@@ -3,7 +3,35 @@ config.default_config.cmd[1] = "./node_modules/.bin/docker-langserver"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install dockerfile-language-server-nodejs@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add dockerfile-language-server-nodejs@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install dockerfile-language-server-nodejs@latest
+  }
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/elm.lua
+++ b/lua/lspinstall/servers/elm.lua
@@ -17,7 +17,36 @@ config.default_config.init_options.elmTestPath = nil
 -- ```
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install elm@latest elm-test@latest elm-format@latest @elm-tooling/elm-language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add elm@latest elm-test@latest elm-format@latest @elm-tooling/elm-language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install elm@latest elm-test@latest elm-format@latest @elm-tooling/elm-language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/ember.lua
+++ b/lua/lspinstall/servers/ember.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = './node_modules/.bin/ember-language-server'
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install @lifeart/ember-language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add @lifeart/ember-language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install @lifeart/ember-language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/graphql.lua
+++ b/lua/lspinstall/servers/graphql.lua
@@ -11,7 +11,36 @@ end
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install graphql-language-service-cli@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add graphql-language-service-cli@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install graphql-language-service-cli@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/lemminx.lua
+++ b/lua/lspinstall/servers/lemminx.lua
@@ -8,9 +8,23 @@ require'lspinstall/servers'.bash = vim.tbl_extend('error', config, {
   -- lspinstall will automatically create/delete the install directory for every server
   install_script = [[
 
-    curl -fLO https://github.com/eclipse/lemminx/archive/refs/tags/0.18.0.tar.gz
-    tar xzvf *.tar.gz
-    rm *.tar.gz
+  os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+  case $os in
+
+  darwin)
+  curl -fLO https://download.jboss.org/jbosstools/vscode/stable/lemminx-binary/0.18.0-400/lemminx-osx-x86_64.zip
+  unzip lemminx-osx-x86_64.zip
+  rm -r lemminx-osx-x86_64.zip
+  ;;
+
+  linux)
+  curl -fLO https://download.jboss.org/jbosstools/vscode/stable/lemminx-binary/0.18.0-400/lemminx-linux.zip
+  unzip lemminx-linux.zip
+  rm -r lemminx-linux.zip
+  ;;
+
+  esac
 
   ]]
 })

--- a/lua/lspinstall/servers/lemminx.lua
+++ b/lua/lspinstall/servers/lemminx.lua
@@ -1,7 +1,7 @@
 -- 1. get the default config from nvim-lspconfig
 local config = require"lspinstall/util".extract_config("lemminx")
 -- 2. update the cmd. relative paths are allowed, lspinstall automatically adjusts the cmd and cmd_cwd for us!
-config.default_config.cmd[1] = "./lemminx-0.18.0/mvnw"
+config.default_config.cmd[1] = "./lemminx"
 
 -- 3. extend the config with an install_script and (optionally) uninstall_script
 require'lspinstall/servers'.bash = vim.tbl_extend('error', config, {
@@ -16,12 +16,14 @@ require'lspinstall/servers'.bash = vim.tbl_extend('error', config, {
   curl -fLO https://download.jboss.org/jbosstools/vscode/stable/lemminx-binary/0.18.0-400/lemminx-osx-x86_64.zip
   unzip lemminx-osx-x86_64.zip
   rm -r lemminx-osx-x86_64.zip
+  mv lemminx-osx-x86_64 lemminx
   ;;
 
   linux)
   curl -fLO https://download.jboss.org/jbosstools/vscode/stable/lemminx-binary/0.18.0-400/lemminx-linux.zip
   unzip lemminx-linux.zip
   rm -r lemminx-linux.zip
+  mv lemminx-linux lemminx
   ;;
 
   esac

--- a/lua/lspinstall/servers/lemminx.lua
+++ b/lua/lspinstall/servers/lemminx.lua
@@ -8,7 +8,7 @@ require'lspinstall/servers'.bash = vim.tbl_extend('error', config, {
   -- lspinstall will automatically create/delete the install directory for every server
   install_script = [[
 
-    curl -L -o https://github.com/eclipse/lemminx/archive/refs/tags/0.18.0.tar.gz
+    curl -fLO https://github.com/eclipse/lemminx/archive/refs/tags/0.18.0.tar.gz
     tar xzvf *.tar.gz
     rm *.tar.gz
 

--- a/lua/lspinstall/servers/lemminx.lua
+++ b/lua/lspinstall/servers/lemminx.lua
@@ -4,7 +4,7 @@ local config = require"lspinstall/util".extract_config("lemminx")
 config.default_config.cmd[1] = "./lemminx"
 
 -- 3. extend the config with an install_script and (optionally) uninstall_script
-require'lspinstall/servers'.bash = vim.tbl_extend('error', config, {
+require'lspinstall/servers'.lemminx = vim.tbl_extend('error', config, {
   -- lspinstall will automatically create/delete the install directory for every server
   install_script = [[
 

--- a/lua/lspinstall/servers/lemminx.lua
+++ b/lua/lspinstall/servers/lemminx.lua
@@ -1,0 +1,16 @@
+-- 1. get the default config from nvim-lspconfig
+local config = require"lspinstall/util".extract_config("lemminx")
+-- 2. update the cmd. relative paths are allowed, lspinstall automatically adjusts the cmd and cmd_cwd for us!
+config.default_config.cmd[1] = "./lemminx-0.18.0/mvnw"
+
+-- 3. extend the config with an install_script and (optionally) uninstall_script
+require'lspinstall/servers'.bash = vim.tbl_extend('error', config, {
+  -- lspinstall will automatically create/delete the install directory for every server
+  install_script = [[
+
+    curl -L -o https://github.com/eclipse/lemminx/archive/refs/tags/0.18.0.tar.gz
+    tar xzvf *.tar.gz
+    rm *.tar.gz
+
+  ]]
+})

--- a/lua/lspinstall/servers/php.lua
+++ b/lua/lspinstall/servers/php.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/intelephense"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install intelephense@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add intelephense@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install intelephense@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/prismals.lua
+++ b/lua/lspinstall/servers/prismals.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/prisma-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install @prisma/language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add @prisma/language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install @prisma/language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/purescript.lua
+++ b/lua/lspinstall/servers/purescript.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/purescript-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install purescript-language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add purescript-language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install purescript-language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/python.lua
+++ b/lua/lspinstall/servers/python.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/pyright-langserver"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install pyright@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add pyright@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install pyright@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/rome.lua
+++ b/lua/lspinstall/servers/rome.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/rome"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install rome@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add rome@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install rome@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/svelte.lua
+++ b/lua/lspinstall/servers/svelte.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/svelteserver"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install svelte-language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add svelte-language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install svelte-language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/tailwindcss.lua
+++ b/lua/lspinstall/servers/tailwindcss.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/tailwindcss-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install @tailwindcss/language-server
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add @tailwindcss/language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install @tailwindcss/language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/typescript.lua
+++ b/lua/lspinstall/servers/typescript.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/typescript-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install typescript-language-server@latest typescript@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add typescript-language-server@latest typescript@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install typescript-language-server@latest typescript@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/vim.lua
+++ b/lua/lspinstall/servers/vim.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/vim-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install vim-language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add vim-language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install vim-language-server@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/vue.lua
+++ b/lua/lspinstall/servers/vue.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/vls"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && npm init -y --scope=lspinstall || true
-  npm install vls@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y --scope=lspinstall || true
+    yarn add vls@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y --scope=lspinstall || true
+    npm install vls@latest
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })

--- a/lua/lspinstall/servers/yaml.lua
+++ b/lua/lspinstall/servers/yaml.lua
@@ -3,7 +3,36 @@ config.default_config.cmd[1] = "./node_modules/.bin/yaml-language-server"
 
 return vim.tbl_extend('error', config, {
   install_script = [[
-  ! test -f package.json && yarn init -y  || true
-  yarn add yaml-language-server@latest
+
+  YARN=/usr/bin/yarn
+  NPM=/usr/bin/npm
+
+  Yarn() {
+    ! test -f package.json && yarn init -y  || true
+    yarn add yaml-language-server@latest --ignore-engines
+  }
+
+  Npm() {
+    ! test -f package.json && npm init -y  || true
+    npm install yaml-language-server@latest --ignore-engines
+  }
+
+  if [ ! -x $NPM ] && [ ! -x $YARN ]; then
+    # if npm and yarn are not on the system
+    printf "\nCan't find npm or yarn on the system\n"
+  elif [ -x $NPM ] && [ -x $YARN ]; then
+    # if npm and yarn are on the system
+    printf "\nFound npm & yarn ... using yarn\n"
+    Yarn
+  elif [ ! -x $NPM ]; then
+    # if npm is not on the system
+    printf "\nNpm not found..."
+    Yarn
+  elif [ ! -x $YARN ]; then
+    # if yarn is not on the system
+    printf "\nYarn not found..."
+    Npm
+  fi
+
   ]]
 })


### PR DESCRIPTION
This pull request adds `yarn` support to LspInstall.

It queries the system for `npm` or `yarn` prior to installing a language server, and if one of the commands is not available, it will use the other. However, if both are present, LspInstall will now default to using `yarn`. (for speed's sake)